### PR TITLE
return a response from generate to catch attempt errors

### DIFF
--- a/src/common/helpers/provider/modules/green/green.ts
+++ b/src/common/helpers/provider/modules/green/green.ts
@@ -51,7 +51,12 @@ export const useGreen = (
 
   const handleGenerateGreen = useCallback(
     async (phoneNumber: string) => {
-      if (masa) await masa?.green.generate(phoneNumber);
+      let response;
+      if (masa) {
+        response = await masa?.green.generate(phoneNumber);
+      }
+
+      return response;
     },
     [masa]
   );


### PR DESCRIPTION
- The generate code function needs to return a response from Twilio if the maximum number of attempts at generating a code has been reached so it can be used in the FE application to display an error