### PR TITLE
feat: export connectModalOpen state from useWallet hook

### DIFF
--- a/src/wallet-client/wallet/use-wallet.ts
+++ b/src/wallet-client/wallet/use-wallet.ts
@@ -54,7 +54,7 @@ export interface UseWalletReturn {
 }
 
 const useWallet = (): UseWalletReturn => {
-  const { openConnectModal } = useConnectModal();
+  const { openConnectModal, connectModalOpen } = useConnectModal();
   const { openChainModal } = useChainModal();
   const { openAccountModal } = useAccountModal();
   const { isConnected, isConnecting, isDisconnected, connector, address } =
@@ -148,6 +148,7 @@ const useWallet = (): UseWalletReturn => {
       isConnecting,
       isDisconnected,
       openConnectModal,
+      connectModalOpen,
       openChainModal,
       openAccountModal,
       disconnect,
@@ -178,6 +179,7 @@ const useWallet = (): UseWalletReturn => {
       isConnecting,
       isDisconnected,
       openConnectModal,
+      connectModalOpen,
       openChainModal,
       openAccountModal,
       disconnect,


### PR DESCRIPTION
## Problem
masa-finance/masa-next-sbt#834  The next app is experiencing a bug when the Connect Wallet modal is closed without an connection action (i.e. the 'x' button is pressed). The FE isn't able to detect this event and therefore is not able to close it's modal overlay component.

## Solution
In the useWallet hook we can export the connectModalOpen state, which the FE can listen to changes for.

## Related Issues
- unblocks masa-finance/masa-next-sbt#834